### PR TITLE
Added missing configuration option

### DIFF
--- a/app/code/community/Snowdog/CreditagricoleRaty/etc/system.xml
+++ b/app/code/community/Snowdog/CreditagricoleRaty/etc/system.xml
@@ -153,6 +153,14 @@
 							<show_in_website>0</show_in_website>
 							<show_in_store>0</show_in_store>
 						</save_logs>
+						<sort_order translate="label">
+							<label>Pozycja na liście</label>
+							<frontend_type>text</frontend_type>
+							<sort_order>500</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>1</show_in_website>
+							<show_in_store>0</show_in_store>
+						</sort_order>
 					</fields>
 				</snowcreditagricoleraty>
 			</groups>


### PR DESCRIPTION
Spora część klientów używa tego, żeby porządkować kolejność metod w checkoutcie.